### PR TITLE
Specify “darwin” as “os” property within package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "electron-native-auth",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/clavin/electron-native-auth.git"
   },
+  "os": ["darwin"],
   "author": "Calvin Watford",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-native-auth",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds the `"os": ["darwin"]` field to the package.json to ensure the electron-native-auth library is only installed on macOS. This ensures installation on supported platforms when the library is listed in `optionalDependencies`.

**Why**
- The library is macOS-specific.
- Without this field, npm will not install the dependency when included in `optionalDependencies`

**Changes**
- Added `"os": ["darwin"]` to package.json.
- Incremented version number

**Benefits**
- Ensures platform-specific compatibility.

**Testing**
- Confirmed the package installs on macOS when package is listed in `optionalDependencies`.